### PR TITLE
Adding stitch example

### DIFF
--- a/Simulations/mixed_continuum_and_pore_network.md
+++ b/Simulations/mixed_continuum_and_pore_network.md
@@ -1,5 +1,14 @@
 # Diffusion in a pore network with continuum nodes
 
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [Diffusion in a pore network with continuum nodes](#diffusion-in-a-pore-network-with-continuum-nodes)
+	- [Create Network Topology](#create-network-topology)
+		- [Stitching Two Networks Together](#stitching-two-networks-together)
+	- [Create Pore-Scale Geometry Objects for each Region](#create-pore-scale-geometry-objects-for-each-region)
+
+<!-- /TOC -->
+
 The utility of pore network modeling derives from its ability to simulate transport processes knowing only geometrical properties such as pore size distribution and connectivity between pores.  In some cases however, it is not possible to computationally resolve all the pores.  For example, diffusion may be occurring through a network of large pores on the order of 100's of um, while a reaction occurs in much smaller pores on the order 1 um.  This situation is commonly found when modeling fuel cell electrodes which are made of several sandwiched layers each with drastically different pores sizes.  
 
 This example illustrates how to create a dual-scale pore network, determine transport parameters on the large scale using pore-size information, while ascribing continuum-like transport properties to a smaller scale.  Gas diffusion with reaction will then be simulated on this dual-scale network.  This loosely follows the approach demonstrated in a recent paper in the [Journal of the Electrochemical Society](http://doi.org/10.1149/2.0701605jes) which treated the catalyst layer as a volume averaged porous continua.  
@@ -20,7 +29,7 @@ Start by creating the network to represent the layer of large pores (~50 um) for
 
 ```
 
-And next create a second network to represent the catalyst layer, which has 200-500 nm pores (100x smaller than the GDL).  We will not attempt to resolve each pore in the CL, since this would mean 1 million pores for each pore on the GDL (so a total of 40 million pores).  Instead, we'll treat the CL as a network of *nodes* with the properties of a porous continua:
+Next create a second network to represent the catalyst layer, which has 200-500 nm pores (100x smaller than the GDL).  We will not attempt to resolve each pore in the CL, since this would mean 1 million pores for each pore on the GDL (so a total of 100 million pores).  Instead, we'll treat the CL as a network of *nodes* with the properties of a porous continua:
 
 ``` python
 >>> CL = op.Network.Cubic(shape=[30, 30, 5], spacing=0.00002)
@@ -29,7 +38,7 @@ And next create a second network to represent the catalyst layer, which has 200-
 
 This means that each pores in the GDL will interface with 9 pores on the CL.  The `shape` and `spacing` were chosen to make the scaling between the layers straight-forward.
 
-### Stitching Two Networks
+### Stitching Two Networks Together
 
 OpenPNM includes an assortment of tools for manipulating network topology.  These functions can be found under `OpenPNM.Utilities.topology`.  For this example we'll use the `stitch` method, which as the name suggests 'stitches' a network onto another, in this case `CL` onto `GDL`.
 
@@ -49,10 +58,9 @@ OpenPNM includes an assortment of tools for manipulating network topology.  Thes
 
 ```
 
-Visualizing the network lattice in Paraview shows that indeed the `CL` was offset the correct amount in the correct direction, and that new throats have been added that creat the desired *stitching*.  
+Visualizing the network lattice in Paraview shows that indeed the `CL` was offset the correct amount in the correct direction, and that new throats have been added that create the desired *stitching*.  
 
-![](url)
-
+![](http://i.imgur.com/AZ6koXA.png)
 
 ## Create Pore-Scale Geometry Objects for each Region
 
@@ -62,14 +70,14 @@ For this example, we'll use the pre-defined Toray090 **Geometry** class which is
 >>> geom_GDL = op.Geometry.Toray090(network=GDL, pores=GDL.pores('GDL'),
 ...                                 throats=GDL.throats('GDL'))
 >>> geom_CL = op.Geometry.GenericGeometry(network=GDL, pores=GDL.pores('CL'),
-...                                       throats=GDL.throts('GDL'))
+...                                       throats=GDL.throats('CL'))
 
 ```
 
-The **Toray090** class contains all the pore and throat pore-scale models required, but we'll need to add models to `geom_CL`. Also, the *stitch* process created numerous new throat connections between the `CL` and `GDL` that are need some sort of geometrical information.  
+The **Toray090** class contains all the pore and throat pore-scale models required, but we'll need to add models to `geom_CL`. Also, the *stitch* process created numerous new throat connections between the `CL` and `GDL` that are need some sort of geometrical information, so let's create a **Geometry** object to handle these:
 
 ``` python
 >>> Ts = GDL.find_interface_throats(labels=['GDL', 'CL'])
->>> geom_stitch = op.GenericGeometry(network=GDL, throats=Ts)
+>>> geom_stitch = op.Geometry.GenericGeometry(network=GDL, throats=Ts)
 
 ```

--- a/Simulations/mixed_continuum_and_pore_network.md
+++ b/Simulations/mixed_continuum_and_pore_network.md
@@ -52,9 +52,9 @@ OpenPNM includes an assortment of tools for manipulating network topology.  Thes
 >>> CL['pore.coords'] -= [0, 0, 0.00002*5]
 >>> # Finally, send both networks to stitch which will stitch CL onto GDL
 >>> pn = op.Utilities.topology.stitch(network=GDL, donor=CL,
-                                      P_network=GDL.pores('bottom'),
-                                      P_donor=GDL.pores('top'),
-                                      len_max=0.00003)
+...                                   P_network=GDL.pores('bottom'),
+...                                   P_donor=GDL.pores('top'),
+...                                   len_max=0.00003)
 
 ```
 

--- a/Simulations/mixed_continuum_and_pore_network.md
+++ b/Simulations/mixed_continuum_and_pore_network.md
@@ -1,0 +1,75 @@
+# Diffusion in a pore network with continuum nodes
+
+The utility of pore network modeling derives from its ability to simulate transport processes knowing only geometrical properties such as pore size distribution and connectivity between pores.  In some cases however, it is not possible to computationally resolve all the pores.  For example, diffusion may be occurring through a network of large pores on the order of 100's of um, while a reaction occurs in much smaller pores on the order 1 um.  This situation is commonly found when modeling fuel cell electrodes which are made of several sandwiched layers each with drastically different pores sizes.  
+
+This example illustrates how to create a dual-scale pore network, determine transport parameters on the large scale using pore-size information, while ascribing continuum-like transport properties to a smaller scale.  Gas diffusion with reaction will then be simulated on this dual-scale network.  This loosely follows the approach demonstrated in a recent paper in the [Journal of the Electrochemical Society](http://doi.org/10.1149/2.0701605jes) which treated the catalyst layer as a volume averaged porous continua.  
+
+| Highlights |
+|------------|
+| 1. Generate two distinct Network topologies and stitch them together |
+| 2. Assign pore-scale conductance models to some pores based continuum mechanics |
+| 3. Add concentration dependent reaction terms to some pores |
+
+## Create Network Topology
+
+Start by creating the network to represent the layer of large pores (~50 um) for the 'gas diffusion layer':
+
+``` python
+>>> import OpenPNM as op
+>>> GDL = op.Network.Cubic(shape=[10, 10, 10], spacing=0.00006)
+
+```
+
+And next create a second network to represent the catalyst layer, which has 200-500 nm pores (100x smaller than the GDL).  We will not attempt to resolve each pore in the CL, since this would mean 1 million pores for each pore on the GDL (so a total of 40 million pores).  Instead, we'll treat the CL as a network of *nodes* with the properties of a porous continua:
+
+``` python
+>>> CL = op.Network.Cubic(shape=[30, 30, 5], spacing=0.00002)
+
+```
+
+This means that each pores in the GDL will interface with 9 pores on the CL.  The `shape` and `spacing` were chosen to make the scaling between the layers straight-forward.
+
+### Stitching Two Networks
+
+OpenPNM includes an assortment of tools for manipulating network topology.  These functions can be found under `OpenPNM.Utilities.topology`.  For this example we'll use the `stitch` method, which as the name suggests 'stitches' a network onto another, in this case `CL` onto `GDL`.
+
+``` python
+>>> # Start by assigning labels to each network for identification later
+>>> CL['pore.CL'] = True
+>>> CL['throat.CL'] = True
+>>> GDL['pore.GDL'] = True
+>>> GDL['throat.GDL'] = True
+>>> # Next manually offset CL one full thickness relative to the GDL
+>>> CL['pore.coords'] -= [0, 0, 0.00002*5]
+>>> # Finally, send both networks to stitch which will stitch CL onto GDL
+>>> pn = op.Utilities.topology.stitch(network=GDL, donor=CL,
+                                      P_network=GDL.pores('bottom'),
+                                      P_donor=GDL.pores('top'),
+                                      len_max=0.00003)
+
+```
+
+Visualizing the network lattice in Paraview shows that indeed the `CL` was offset the correct amount in the correct direction, and that new throats have been added that creat the desired *stitching*.  
+
+![](url)
+
+
+## Create Pore-Scale Geometry Objects for each Region
+
+For this example, we'll use the pre-defined Toray090 **Geometry** class which is a typical gas diffusion layer material used in fuel cells, but we'll create a custom **Geometry** for the catalyst layer section.  The following uses the `GDL` and `CL` labels we created prior to stitching.  
+
+``` python
+>>> geom_GDL = op.Geometry.Toray090(network=GDL, pores=GDL.pores('GDL'),
+...                                 throats=GDL.throats('GDL'))
+>>> geom_CL = op.Geometry.GenericGeometry(network=GDL, pores=GDL.pores('CL'),
+...                                       throats=GDL.throts('GDL'))
+
+```
+
+The **Toray090** class contains all the pore and throat pore-scale models required, but we'll need to add models to `geom_CL`. Also, the *stitch* process created numerous new throat connections between the `CL` and `GDL` that are need some sort of geometrical information.  
+
+``` python
+>>> Ts = GDL.find_interface_throats(labels=['GDL', 'CL'])
+>>> geom_stitch = op.GenericGeometry(network=GDL, throats=Ts)
+
+```

--- a/Topology/stitching_networks_together.md
+++ b/Topology/stitching_networks_together.md
@@ -10,7 +10,7 @@ Start by creating a network with a large lattice spacing:
 >>> import matplotlib.pyplot as pyplot
 >>> # Import OpenPNM and initialize the workspace manager
 >>> import OpenPNM as op
->>> sim = op.Base.workspace()
+>>> sim = op.Base.Workspace()
 >>> sim.clear()  # Clear the existing workspace (mostly for testing purposes)
 >>> coarse_net = op.Network.Cubic(shape=[10, 10, 10], spacing=0.00005)
 

--- a/Topology/stitching_networks_together.md
+++ b/Topology/stitching_networks_together.md
@@ -10,7 +10,7 @@ Start by creating a network with a large lattice spacing:
 >>> import matplotlib.pyplot as pyplot
 >>> # Import OpenPNM and initialize the workspace manager
 >>> import OpenPNM as op
->>> sim = op.workspace()
+>>> sim = op.Base.workspace()
 >>> sim.clear()  # Clear the existing workspace (mostly for testing purposes)
 >>> coarse_net = op.Network.Cubic(shape=[10, 10, 10], spacing=0.00005)
 

--- a/Topology/stitching_networks_together.md
+++ b/Topology/stitching_networks_together.md
@@ -1,0 +1,66 @@
+## Create Network Topology
+
+OpenPNM includes numerous tools for manipulating and altering the topology.  Most of these are found unter **Network.tools**.  This example will illustrate who to join or 'stitch' two distinct networks, even if they have different lattice spacing.  In this example we'll create a coarse and a fine network then stitch them together to make a network with two distinct layers.  
+
+Start by creating a network with a large lattice spacing:
+
+``` python
+>>> # Import the usual suspects
+>>> import scipy as sp
+>>> import matplotlib.pyplot as pyplot
+>>> # Import OpenPNM and initialize the workspace manager
+>>> import OpenPNM as op
+>>> sim = op.workspace()
+>>> sim.clear()  # Clear the existing workspace (mostly for testing purposes)
+>>> coarse_net = op.Network.Cubic(shape=[10, 10, 10], spacing=0.00005)
+
+```
+
+The ```coarse_net``` network has 1000 pores in a cubic lattice with a spacing of 50 um for a total size of 500 um per size.  Next, we'll make another network with smaller spacing between pores, but with the same total size.
+
+``` python
+>>> fine_net = op.Network.Cubic(shape=[25, 25, 5], spacing=0.00002)
+
+```
+
+These two networks are totally independent of each other, and actually both spatially overlap each other since the network generator places the pores at the [0, 0, 0] origin.  Combining these networks into a single network is possible using the ```stitch``` function, but first we must make some adjustments.  For starters, let's shift the ```fine_net``` along the z-axis so it is beside the ```coarse_net``` to give the layered effect:
+
+``` python
+>>> fine_net['pore.coords'] += sp.array([0, 0, 0.0005])
+
+```
+
+Before proceeding, let's quickly check that the two networks are indeed spatially separated now:
+
+``` python
+>>> fig = op.Network.tools.plot_connections(coarse_net)
+>>> fig = op.Network.tools.plot_connections(fine_net, fig=fig)
+
+```
+
+As can be seen below, ```fine_net``` (orange) has been repositioned above the ```coarse_net``` (blue).
+
+![](https://i.imgur.com/8nEBCpf.png)
+
+Now it's time stitch the networks together by adding throats between the pores on the top of the coarse network and those on the bottom of the fine network. The ```stitch``` function uses Euclidean distance to determine which pore is each face is nearest each other, and connects them.  
+
+``` python
+>>> op.Network.tools.stitch(network=fine_net, donor=coarse_net,
+...                         P_network=fine_net.pores('bottom'),
+...                         P_donor=coarse_net.pores('top'),
+...                         len_max=0.00004)
+
+```
+
+And we can quickly visualize the result using OpenPNM's plotting tools:
+
+``` python
+>>> fig = op.Network.tools.plot_connections(fine_net)
+
+```
+
+The diagonal throats between the two networks have been added by the stitch process:
+
+![](https://i.imgur.com/6oLq9wv.png)
+
+The next step would be to assign different geometry objects to each network, with different pore sizes and such.


### PR DESCRIPTION
This example illustrates how to stitch two networks together, treats one of the networks as a continua, and then performs a gas diffusion with reaction simulation.
